### PR TITLE
Correção do loader do busca cep + mascara no campo celular

### DIFF
--- a/Plugin/Checkout/LayoutProcessor.php
+++ b/Plugin/Checkout/LayoutProcessor.php
@@ -160,6 +160,11 @@ class LayoutProcessor
         ['children']['shippingAddress']['children']['shipping-address-fieldset']
         ['children']['telephone']['component'] = 'SystemCode_BrazilCustomerAttributes/js/shipping-address/address-renderer/telephone';
 
+        // Fax
+        $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']
+        ['children']['shippingAddress']['children']['shipping-address-fieldset']
+        ['children']['fax']['component'] = 'SystemCode_BrazilCustomerAttributes/js/shipping-address/address-renderer/telephone';
+
         return $jsLayout;
     }
 
@@ -265,6 +270,11 @@ class LayoutProcessor
                 $jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']
                 ['payment']['children']['payments-list']['children'][$paymentMethodCode . '-form']['children']
                 ['form-fields']['children']['telephone']['component'] = 'SystemCode_BrazilCustomerAttributes/js/shipping-address/address-renderer/telephone';
+
+                // Fax
+                $jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']
+                ['payment']['children']['payments-list']['children'][$paymentMethodCode . '-form']['children']
+                ['form-fields']['children']['fax']['component'] = 'SystemCode_BrazilCustomerAttributes/js/shipping-address/address-renderer/telephone';
             }
         }
 

--- a/view/frontend/web/js/form/address-mixin.js
+++ b/view/frontend/web/js/form/address-mixin.js
@@ -1,12 +1,19 @@
 require([
     'jquery',
     'inputMask',
-    'mage/url'
+    'mage/url',
+    'loader',
 ], function ($, mask, url) {
     $("#postcode").mask('00000-000', {clearIfNotMatch: true});
     $('#postcode').change(function(){
-        zipcode = $(this).val().replace('-', '');
+        var zipcode = $(this).val().replace('-', '');
         var ajaxurl = url.build("brcustomer/consult/address/zipcode/"+zipcode);
+
+        if (zipcode.length !== 8) {
+            return;
+        }
+
+        $('body').loader('show');
 
         $.ajax({
             url: ajaxurl,
@@ -24,8 +31,10 @@ require([
                 $("#country").val('BR');
                 $("#region_id").val(data.uf);
             }
-            $('#checkout-loader').remove();
-        }).error(function(){});
+            $('body').loader('hide');
+        }).error(function () {
+            $('body').loader('show');
+        });
     });
 
     var SPMaskBehavior = function (val) {
@@ -39,4 +48,5 @@ require([
         };
 
     $('#telephone').mask(SPMaskBehavior, spOptions);
+    $('#fax').mask(SPMaskBehavior, spOptions);
 });

--- a/view/frontend/web/js/shipping-address/address-renderer/zip-code.js
+++ b/view/frontend/web/js/shipping-address/address-renderer/zip-code.js
@@ -6,6 +6,7 @@ define([
     'jquery',
     'inputMask',
     'mage/url',
+    'loader',
 ], function (_, ko, registry, Abstract, jquery, mask, url) {
     'use strict';
 
@@ -63,8 +64,8 @@ define([
             //    return;
             //}
 
-            if(validate.valid == true && this.value() && this.value().length == 9){
-                jquery('#checkout').append(checkoutLoader);
+            if(validate.valid == true && this.value() && this.value().length == 9) {
+                jquery('body').loader('show');
 
                 var element = this;
 
@@ -100,12 +101,10 @@ define([
                             registry.get(element.parentName + '.' + 'country_id').value('BR');
                         }
                     }
-                    jquery('#checkout-loader').remove();
+                    jquery('body').loader('hide');
                 }).error(function(){
-                    jquery('#checkout-loader').remove();
+                    jquery('body').loader('hide');
                 });
-            }else{
-                jquery('#checkout-loader').remove();
             }
 
         }


### PR DESCRIPTION
Remover o elemento `#checkout-loader` causa erro em alguns módulos de onestepcheckout.
